### PR TITLE
Fixed 'Internal .Net Framework Data Provider error 1'

### DIFF
--- a/src/capex.mssql/MSSQLDatabaseForDotNet@target_netx.sling
+++ b/src/capex.mssql/MSSQLDatabaseForDotNet@target_netx.sling
@@ -133,9 +133,6 @@ class ResultSet is SQLResultSetIterator
 	var reader public as !"System.Data.SqlClient.SqlDataReader"
 	var connection public as !"System.Data.SqlClient.SqlConnection"
 
-	dtor:
-		close()
-
 	func close override
 	{
 		if reader {


### PR DESCRIPTION
Accordingly, we should not call Close() or Dispose() on a Connection, a DataReader, or any other managed object in the Finalize method of our class. So I removed the dtor of the ResultSet class definition since we call the close() method in it which would call the Close() methods of its connection and reader.

reference: https://social.msdn.microsoft.com/Forums/en-US/b23d8492-1696-4ccb-b4d9-3e7fbacab846/internal-net-framework-data-provider-error-1?forum=adodotnetdataproviders