### PR TITLE
Fixed HTTPServerSQLUtil.getSQLParameterVectorFromQuery() method compatibility issue with MSSQL and MySQL database classes

### DIFF
--- a/src/capex.data/SQLAdoNet@target_netx.sling
+++ b/src/capex.data/SQLAdoNet@target_netx.sling
@@ -33,7 +33,7 @@ func convertSQLString(sql as string) static as string
 	var quote = false
 	var dquote = false
 	var slash = false
-	var n = 1
+	var n = 0
 	var it = String.iterate(sql)
 	if(it == null) {
 		return(null)

--- a/src/capex.mssql/MSSQLDatabaseForDotNet@target_netx.sling
+++ b/src/capex.mssql/MSSQLDatabaseForDotNet@target_netx.sling
@@ -77,8 +77,9 @@ class Statement is SQLStatement
 
 	func getNextParamName as string
 	{
+		var v = "@p" .. String.forInteger(pcounter)
 		pcounter ++
-		return "@p" .. String.forInteger(pcounter)
+		return v
 	}
 
 	func addParamString(val as string) as SQLStatement:
@@ -390,7 +391,7 @@ func execute(stmt as SQLStatement) override as bool
 				}
 				System.Data.SqlClient.SqlParameter[] pa = ss.getParamArray();
 				if(pa != null) {
-					cmd.Parameters.AddRange(ss.getParamArray());
+					cmd.Parameters.AddRange(pa);
 				}
 				conn.Open();
 				cmd.ExecuteNonQuery();
@@ -424,7 +425,7 @@ func query(stmt as SQLStatement) override as SQLResultSetIterator
 			}
 			System.Data.SqlClient.SqlParameter[] pa = ss.getParamArray();
 			if(pa != null) {
-				cmd.Parameters.AddRange(ss.getParamArray());
+				cmd.Parameters.AddRange(pa);
 			}
 			connection.Open();
 			reader = cmd.ExecuteReader();

--- a/src/capex.mysql/MySQLDatabaseForDotNet@target_netx.sling
+++ b/src/capex.mysql/MySQLDatabaseForDotNet@target_netx.sling
@@ -77,8 +77,9 @@ class Statement is SQLStatement
 
 	func getNextParamName as string
 	{
+		var v = "@p" .. String.forInteger(pcounter)
 		pcounter ++
-		return "@p" .. String.forInteger(pcounter)
+		return v
 	}
 
 	func addParamString(val as string) as SQLStatement:


### PR DESCRIPTION
HTTPServerSQLUtil.getSQLParameterVectorFromQuery() method starts with 0 ('p0') query parameter while the SQL databases MSSQL and MySQL including SQLAdoNet start with 1 ('@p1').