### PR TITLE
changed ifdef to else ifdef

### DIFF
--- a/src/cape/CurrentThread.sling
+++ b/src/cape/CurrentThread.sling
@@ -61,7 +61,7 @@ func sleepMilliSeconds(mSeconds as int) static
 			}
 		}}}
 	}
-	IFDEF "target_kotlin" {
+	ELSE IFDEF "target_kotlin" {
 		lang "kotlin" {{{
 			java.lang.Thread.sleep(mSeconds.toLong())
 		}}}


### PR DESCRIPTION
When running server application on target cs, it always prints out the error message "not implemented" due to having an IFDEF "target_kotlin" where it is always false since target is cs hence the error message found on ELSE.