### PR TITLE
[#55]added datavalidator and bcrypt for sushi

### DIFF
--- a/src/jk.bcrypt/BCryptEncoderSushi@target_sushi.sling
+++ b/src/jk.bcrypt/BCryptEncoderSushi@target_sushi.sling
@@ -23,47 +23,21 @@
  * SOFTWARE.
  */
 
-import jk.log
+class is BCryptEncoder:
 
-class abstract:
+func generateSalt(logRounds as int, bCryptVersion as string) override as string:
+	return lang "lua" string {{{ _bcrypt:generate_salt(logRounds) }}}
 
-func create static as this
+func hashPassword(password as string, salt as string) override as string:
+	return lang "lua" string {{{ _bcrypt:hash_password(password, salt) }}}
+
+func checkPassword(password as string, hash as string) override as bool
 {
-	IFDEF "target_cs" {
-		return new BCryptEncoderCS()
-	}
-	ELSE IFDEF "target_sushi" {
-		return new BCryptEncoderSushi()
-	}
-	ELSE {
-		return new BCryptEncoderGeneric()
-	}
+	var v as int
+	lang "lua" {{{
+		v = _bcrypt:check_password(password, hash)
+	}}}
+	if v == 0:
+		return true
+	return false
 }
-
-func forLoggingContext(ctx as LoggingContext) static as this
-{
-	var v = assert create()
-	v.setCtx(ctx)
-	return v
-}
-
-var ctx protected as LoggingContext
-
-func setCtx(ctx as LoggingContext) as this
-{
-	this.ctx = ctx
-	return this
-}
-
-func getCtx as LoggingContext:
-	return ctx
-
-func generateSalt as string:
-	return generateSalt(10)
-
-func generateSalt(logRounds as int) as string:
-	return generateSalt(logRounds, "2a")
-
-func generateSalt(logRounds as int, bCryptVersion as string) abstract as string
-func hashPassword(password as string, salt as string) abstract as string
-func checkPassword(password as string, hash as string) abstract as bool

--- a/src/jk.util.validator/DataValidator.sling
+++ b/src/jk.util.validator/DataValidator.sling
@@ -25,7 +25,7 @@
 
 class:
 
-func checkEmailAddress(emailAddress as string) static as Error
+func isEmailAddressValid(emailAddress as string) static as bool
 {
 	meta
 	{
@@ -35,12 +35,12 @@ func checkEmailAddress(emailAddress as string) static as Error
 		]]
 	}
 	if String.isEmpty(emailAddress):
-		return Error.forCode("noEmailAddress")
+		return false
 	if String.getLength(emailAddress) > 254:
-		return Error.forCode("noEmailAddress")
+		return false
 	var ci = String.iterate(emailAddress)
 	if not ci:
-		return Error.forCode("invalidEmailAddress")
+		return false
 	var insideQuotation = false
 	var outsideQuotation = false
 	var dotPreceded = false
@@ -54,7 +54,7 @@ func checkEmailAddress(emailAddress as string) static as Error
 			break
 		if outsideQuotation {
 			if c != 46 && c != 64:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		if c >= 65 && c <= 90 {
 			;
@@ -97,15 +97,15 @@ func checkEmailAddress(emailAddress as string) static as Error
 		}
 		else if c == 46 {
 			if isFirstCharacter:
-				return Error.forCode("invalidEmailAddress")
+				return false
 			if dotPreceded && not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 			dotPreceded = true
 			continue
 		}
 		else if c == 32 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 34 {
 			if insideQuotation {
@@ -114,87 +114,87 @@ func checkEmailAddress(emailAddress as string) static as Error
 			}
 			else {
 				if not isFirstCharacter && not dotPreceded:
-					return Error.forCode("invalidEmailAddress")
+					return false
 				insideQuotation = true
 				outsideQuotation = false
 			}
 		}
 		else if c == 40 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 41 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 44 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 58 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 59 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 60 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 62 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 64 {
 			if isFirstCharacter:
-				return Error.forCode("invalidEmailAddress")
+				return false
 			if not insideQuotation {
 				if dotPreceded:
-					return Error.forCode("invalidEmailAddress")
+					return false
 				containsAtCharacter = true
 				break
 			}
 		}
 		else if c == 91 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 92 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else if c == 93 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		else {
-			return Error.forCode("invalidEmailAddress")
+			return false
 		}
 		isFirstCharacter = false
 		dotPreceded = false
 	}
 	if i < 0:
-		return Error.forCode("invalidEmailAddress")
+		return false
 	if (i > 64):
-		return Error.forCode("invalidEmailAddress")
+		return false
 	if not containsAtCharacter:
-		return Error.forCode("invalidEmailAddress")
+		return false
 	var domain = String.getSubString(emailAddress, i + 1, String.getLength(emailAddress))
 	if String.isEmpty(domain):
-		return Error.forCode("invalidEmailAddress")
+		return false
 	if String.getLength(domain) > 253:
-		return Error.forCode("invalidEmailAddress")
+		return false
 	if String.startsWith(domain, "[") {
 		if not String.endsWith(domain, "]"):
-			return Error.forCode("invalidEmailAddress")
+			return false
 		var ip = String.getSubString(domain, 1, String.getLength(domain) - 2)
 		if String.isEmpty(ip):
-			return Error.forCode("invalidEmailAddress")
+			return false
 		var nodes = String.split(ip, '.')
 		if not nodes || sizeof nodes != 4:
-			return Error.forCode("invalidEmailAddress")
+			return false
 		foreach node in nodes {
 			ci = String.iterate(node)
 			loop {
@@ -205,23 +205,23 @@ func checkEmailAddress(emailAddress as string) static as Error
 					;
 				}
 				else {
-					return Error.forCode("invalidEmailAddress")
+					return false
 				}
 			}
 			var n = String.toInteger(node)
 			if n < 0 || n > 255:
-				return Error.forCode("invalidEmailAddress")
+				return false
 		}
 		return null
 	}
 	foreach label in String.split(domain, '.') {
 		if String.isEmpty(label):
-			return Error.forCode("invalidEmailAddress")
+			return false
 		if String.getLength(label) > 63:
-			return Error.forCode("invalidEmailAddress")
+			return false
 		ci = String.iterate(label)
 		if not ci:
-			return Error.forCode("invalidEmailAddress")
+			return false
 		var hyphenPreceded = false
 		isFirstCharacter = true
 		loop {
@@ -239,19 +239,19 @@ func checkEmailAddress(emailAddress as string) static as Error
 			}
 			else if c == 45 {
 				if isFirstCharacter:
-					return Error.forCode("invalidEmailAddress")
+					return false
 				hyphenPreceded = true
 				isFirstCharacter = false
 				continue
 			}
 			else {
-				return Error.forCode("invalidEmailAddress")
+				return false
 			}
 			hyphenPreceded = false
 			isFirstCharacter = false
 		}
 		if hyphenPreceded:
-			return Error.forCode("invalidEmailAddress")
+			return false
 	}
-	return null
+	return true
 }

--- a/src/jk.util.validator/DataValidator.sling
+++ b/src/jk.util.validator/DataValidator.sling
@@ -35,12 +35,12 @@ func checkEmailAddress(emailAddress as string) static as Error
 		]]
 	}
 	if String.isEmpty(emailAddress):
-		return Error.forCode("noEmailAddress", "Please specify your email address")
+		return Error.forCode("noEmailAddress")
 	if String.getLength(emailAddress) > 254:
-		return Error.forCode("noEmailAddress", "Please specify your email address")
+		return Error.forCode("noEmailAddress")
 	var ci = String.iterate(emailAddress)
 	if not ci:
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	var insideQuotation = false
 	var outsideQuotation = false
 	var dotPreceded = false
@@ -54,7 +54,7 @@ func checkEmailAddress(emailAddress as string) static as Error
 			break
 		if outsideQuotation {
 			if c != 46 && c != 64:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		if c >= 65 && c <= 90 {
 			;
@@ -97,15 +97,15 @@ func checkEmailAddress(emailAddress as string) static as Error
 		}
 		else if c == 46 {
 			if isFirstCharacter:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 			if dotPreceded && not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 			dotPreceded = true
 			continue
 		}
 		else if c == 32 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 34 {
 			if insideQuotation {
@@ -114,87 +114,87 @@ func checkEmailAddress(emailAddress as string) static as Error
 			}
 			else {
 				if not isFirstCharacter && not dotPreceded:
-					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+					return Error.forCode("invalidEmailAddress")
 				insideQuotation = true
 				outsideQuotation = false
 			}
 		}
 		else if c == 40 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 41 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 44 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 58 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 59 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 60 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 62 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 64 {
 			if isFirstCharacter:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 			if not insideQuotation {
 				if dotPreceded:
-					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+					return Error.forCode("invalidEmailAddress")
 				containsAtCharacter = true
 				break
 			}
 		}
 		else if c == 91 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 92 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else if c == 93 {
 			if not insideQuotation:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		else {
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		}
 		isFirstCharacter = false
 		dotPreceded = false
 	}
 	if i < 0:
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	if (i > 64):
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	if not containsAtCharacter:
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	var domain = String.getSubString(emailAddress, i + 1, String.getLength(emailAddress))
 	if String.isEmpty(domain):
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	if String.getLength(domain) > 253:
-		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		return Error.forCode("invalidEmailAddress")
 	if String.startsWith(domain, "[") {
 		if not String.endsWith(domain, "]"):
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		var ip = String.getSubString(domain, 1, String.getLength(domain) - 2)
 		if String.isEmpty(ip):
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		var nodes = String.split(ip, '.')
 		if not nodes || sizeof nodes != 4:
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		foreach node in nodes {
 			ci = String.iterate(node)
 			loop {
@@ -205,23 +205,23 @@ func checkEmailAddress(emailAddress as string) static as Error
 					;
 				}
 				else {
-					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+					return Error.forCode("invalidEmailAddress")
 				}
 			}
 			var n = String.toInteger(node)
 			if n < 0 || n > 255:
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 		}
 		return null
 	}
 	foreach label in String.split(domain, '.') {
 		if String.isEmpty(label):
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		if String.getLength(label) > 63:
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		ci = String.iterate(label)
 		if not ci:
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 		var hyphenPreceded = false
 		isFirstCharacter = true
 		loop {
@@ -239,19 +239,19 @@ func checkEmailAddress(emailAddress as string) static as Error
 			}
 			else if c == 45 {
 				if isFirstCharacter:
-					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+					return Error.forCode("invalidEmailAddress")
 				hyphenPreceded = true
 				isFirstCharacter = false
 				continue
 			}
 			else {
-				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				return Error.forCode("invalidEmailAddress")
 			}
 			hyphenPreceded = false
 			isFirstCharacter = false
 		}
 		if hyphenPreceded:
-			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			return Error.forCode("invalidEmailAddress")
 	}
 	return null
 }

--- a/src/jk.util.validator/DataValidator.sling
+++ b/src/jk.util.validator/DataValidator.sling
@@ -1,0 +1,257 @@
+
+/*
+ * This file is part of Jkop
+ * Copyright (c) 2016-2018 Job and Esther Technologies Oy
+ * Copyright (c) 2018-2020 Eqela Oy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+class:
+
+func checkEmailAddress(emailAddress as string) static as Error
+{
+	meta
+	{
+		description [[
+			Addr-Spec Specification
+			Reference https://tools.ietf.org/html/rfc5322#page-17
+		]]
+	}
+	if String.isEmpty(emailAddress):
+		return Error.forCode("noEmailAddress", "Please specify your email address")
+	if String.getLength(emailAddress) > 254:
+		return Error.forCode("noEmailAddress", "Please specify your email address")
+	var ci = String.iterate(emailAddress)
+	if not ci:
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	var insideQuotation = false
+	var outsideQuotation = false
+	var dotPreceded = false
+	var isFirstCharacter = true
+	var containsAtCharacter = false
+	var i = -1
+	loop {
+		i ++
+		var c = ci.getNextChar()
+		if c < 1:
+			break
+		if outsideQuotation {
+			if c != 46 && c != 64:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		if c >= 65 && c <= 90 {
+			;
+		}
+		else if c >= 97 && c <= 122 {
+			;
+		}
+		else if c >= 48 && c <= 57 {
+			;
+		}
+		else if c == 33 {
+			;
+		}
+		else if c >= 35 && c <= 39 {
+			;
+		}
+		else if c == 42 {
+			;
+		}
+		else if c == 43 {
+			;
+		}
+		else if c == 45 {
+			;
+		}
+		else if c == 47 {
+			;
+		}
+		else if c == 61 {
+			;
+		}
+		else if c == 63 {
+			;
+		}
+		else if c >= 94 && c <= 96 {
+			;
+		}
+		else if c >= 123 && c <= 126 {
+			;
+		}
+		else if c == 46 {
+			if isFirstCharacter:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			if dotPreceded && not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			dotPreceded = true
+			continue
+		}
+		else if c == 32 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 34 {
+			if insideQuotation {
+				insideQuotation = false
+				outsideQuotation = true
+			}
+			else {
+				if not isFirstCharacter && not dotPreceded:
+					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				insideQuotation = true
+				outsideQuotation = false
+			}
+		}
+		else if c == 40 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 41 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 44 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 58 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 59 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 60 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 62 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 64 {
+			if isFirstCharacter:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			if not insideQuotation {
+				if dotPreceded:
+					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				containsAtCharacter = true
+				break
+			}
+		}
+		else if c == 91 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 92 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else if c == 93 {
+			if not insideQuotation:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		else {
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		isFirstCharacter = false
+		dotPreceded = false
+	}
+	if i < 0:
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	if (i > 64):
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	if not containsAtCharacter:
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	var domain = String.getSubString(emailAddress, i + 1, String.getLength(emailAddress))
+	if String.isEmpty(domain):
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	if String.getLength(domain) > 253:
+		return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	if String.startsWith(domain, "[") {
+		if not String.endsWith(domain, "]"):
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		var ip = String.getSubString(domain, 1, String.getLength(domain) - 2)
+		if String.isEmpty(ip):
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		var nodes = String.split(ip, '.')
+		if not nodes || sizeof nodes != 4:
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		foreach node in nodes {
+			ci = String.iterate(node)
+			loop {
+				var c = ci.getNextChar()
+				if c < 1:
+					break
+				if c >= 48 && c <= 57 {
+					;
+				}
+				else {
+					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				}
+			}
+			var n = String.toInteger(node)
+			if n < 0 || n > 255:
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		}
+		return null
+	}
+	foreach label in String.split(domain, '.') {
+		if String.isEmpty(label):
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		if String.getLength(label) > 63:
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		ci = String.iterate(label)
+		if not ci:
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+		var hyphenPreceded = false
+		isFirstCharacter = true
+		loop {
+			var c = ci.getNextChar()
+			if c < 1:
+				break
+			if c >= 65 && c <= 90 {
+				;
+			}
+			else if c >= 97 && c <= 122 {
+				;
+			}
+			else if c >= 48 && c <= 57 {
+				;
+			}
+			else if c == 45 {
+				if isFirstCharacter:
+					return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+				hyphenPreceded = true
+				isFirstCharacter = false
+				continue
+			}
+			else {
+				return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+			}
+			hyphenPreceded = false
+			isFirstCharacter = false
+		}
+		if hyphenPreceded:
+			return Error.forCode("invalidEmailAddress", "Please specify a valid email address")
+	}
+	return null
+}


### PR DESCRIPTION
Email validator feature, and the following are the emails tested with the datavalidator.

Valid email addresses
simple@example.com
very.common@example.com
disposable.style.email.with+symbol@example.com
other.email-with-hyphen@example.com
fully-qualified-domain@example.com
user.name+tag+sorting@example.com (may go to user.name@example.com inbox depending on mail server)
x@example.com (one-letter local-part)
example-indeed@strange-example.com
admin@mailserver1 (local domain name with no TLD, although ICANN highly discourages dotless email addresses[13])
example@s.example (see the List of Internet top-level domains)
" "@example.org (space between the quotes)
"john..doe"@example.org (quoted double dot)
mailhost!username@example.org (bangified host route used for uucp mailers)
user%example.com@example.org (% escaped mail route to user@example.com via example.org)
Invalid email addresses
Abc.example.com (no @ character)
A@b@c@example.com (only one @ is allowed outside quotation marks)
a"b(c)d,e:f;gi[j\k]l@example.com (none of the special characters in this local-part are allowed outside quotation marks)
just"not"right@example.com (quoted strings must be dot separated or the only element making up the local-part)
this is"not\allowed@example.com (spaces, quotes, and backslashes may only exist when within quoted strings and preceded by a backslash)
this\ still"not\allowed@example.com (even if escaped (preceded by a backslash), spaces, quotes, and backslashes must still be contained by quotes)
1234567890123456789012345678901234567890123456789012345678901234+x@example.com (local part is longer than 64 characters)